### PR TITLE
Fix: Collisions were being checked 3 times for each pipe

### DIFF
--- a/core/src/com/underwater/demo/overflappy/GameScreenScript.java
+++ b/core/src/com/underwater/demo/overflappy/GameScreenScript.java
@@ -147,10 +147,10 @@ public class GameScreenScript implements IScript {
 					}
 					pipe.setX(pipe.getX() - delta * stage.gameSpeed);
 				}
-				
-				//check for collision with bird
-				collisionCheck();
 			}
+
+			//check for collision with bird
+			collisionCheck();
 		}
 		
 		// update scorel label


### PR DESCRIPTION
Hey, the collisionCheck(); call was being done inside a for loop for each pipe, and inside collisionCheck, the for loop was being done again.
I removed the call from the first for loop. Now it checks for collisions one time for each pipe, instead of three.
